### PR TITLE
Changes on Duplicatte handling

### DIFF
--- a/models/base/ga/ga_proc.sql
+++ b/models/base/ga/ga_proc.sql
@@ -60,7 +60,7 @@ FROM (
                 unix_date(month) unix_date,
                 time_of_entry,
                 cast(time_of_entry as date) date_of_entry,
-                first_value(time_of_entry) OVER (PARTITION BY view, landing_page_path, hostname, month ORDER BY time_of_entry desc) lv,
+                last_value(time_of_entry) OVER (PARTITION BY view, landing_page_path, hostname, month ORDER BY time_of_entry desc) lv,
                 replace(hostname,'www.','') hostname,
                 trim(replace(hostname,'www.',''),'/') hostname_trimmed,
                 landing_page_path,

--- a/models/base/search-console/search_console_keyword_proc.sql
+++ b/models/base/search-console/search_console_keyword_proc.sql
@@ -38,7 +38,7 @@ FROM (
 		unix_date(month) as unix_date,
 		time_of_entry,
 		cast(time_of_entry as date) date_of_entry,
-		first_value(time_of_entry) OVER (PARTITION BY requested_object, landing_page, search_query, month ORDER BY time_of_entry desc) lv,	
+		last_value(time_of_entry) OVER (PARTITION BY requested_object, landing_page, search_query, month ORDER BY time_of_entry desc) lv,	
 		requested_object as account,
 		landing_page,
 		search_query as keyword,

--- a/models/base/search-console/search_console_url_proc.sql
+++ b/models/base/search-console/search_console_url_proc.sql
@@ -17,7 +17,7 @@ FROM (
 	unix_date(month) as unix_date,
 	time_of_entry,
 	cast(time_of_entry as date) date_of_entry,
-	first_value(time_of_entry) OVER (PARTITION BY requested_object, landing_page, month ORDER BY time_of_entry desc) lv,	
+	last_value(time_of_entry) OVER (PARTITION BY requested_object, landing_page, month ORDER BY time_of_entry desc) lv,	
 	requested_object as account,
 	lower(regexp_replace(replace(replace(replace(landing_page,'www.',''),'http://',''),'https://',''),r'\#.*$','')) url_untrimmed,
 	trim(lower(regexp_replace(replace(replace(replace(landing_page,'www.',''),'http://',''),'https://',''),r'\#.*$','')),'/') url_trimmed,


### PR DESCRIPTION
* Use last_value instead of first_value to filter out duplicates: given that we are updating data regularly, having the most up to date version of the value would be better.