### PR TITLE
Avoid double count of sites in GA

### DIFF
--- a/models/base/ga/ga_proc_url_mapping.sql
+++ b/models/base/ga/ga_proc_url_mapping.sql
@@ -36,7 +36,7 @@ FROM (
     ON (
         a.date = b.report_date AND 
         a.site = b.site AND 
-        ( a.url = b.url OR concat(a.url, '/') = b.url )
+         a.url = b.url 
     )
 )
 GROUP BY site, domain, account, date, unix_date, url


### PR DESCRIPTION
* On the ga_proc_url_mapping model where we join ga with deepcrawl url, some pages get duplicated as they have versions with and without  "/" at the end of their page path. To avoid this double count the change just matches the default version if ga with the one in deepcrawl.