### PR TITLE
GSC Match Issue

### DIFF
--- a/models/base/search-console/search_console_url_proc_url_mapping.sql
+++ b/models/base/search-console/search_console_url_proc_url_mapping.sql
@@ -29,7 +29,7 @@ FROM (
     ON (
         a.date = b.report_date AND 
         a.site = b.site AND 
-    	( a.url = b.url OR concat(a.url, '/') = b.url )
+    	a.url = b.url
     )        
 )
 GROUP BY site, domain, account, date, unix_date, url


### PR DESCRIPTION
* Deleted an OR condition on the match by URL within the join. This was causing dups where we would have the same version of a landing page with and without "/" at the end of it.

We also already account for the case where there is no URL from the deepcrawl_stats above (line 20), so this condition was redundant.