### PR TITLE
Adding check for canonical URL trailing slash

### DIFF
--- a/models/base/deepcrawl/deepcrawl_proc.sql
+++ b/models/base/deepcrawl/deepcrawl_proc.sql
@@ -370,6 +370,7 @@ WHERE latest_crawl_datetime = crawl_datetime
 AND latest_crawl_id = crawl_id
 AND latest_query_string_url = query_string_url
 AND latest_event_id = eventid
+AND max_trailing_slash_match = url_canonical_trailing_slash_match
 GROUP BY   crawl_id,
   latest_crawl_id,
   urls_to_canonical,

--- a/models/base/deepcrawl/deepcrawl_proc.sql
+++ b/models/base/deepcrawl/deepcrawl_proc.sql
@@ -88,9 +88,7 @@ FROM (
     b.site,
     CASE WHEN url = canonical_url THEN url
       WHEN url_stripped = canonical_url_stripped AND query_string_url_first_param = query_string_canonical_url THEN canonical_url
-      -- WHEN query_string_url_first_param is not null THEN null
-      -- WHEN http_status_code = 404 THEN url
-      ELSE url_stripped
+      ELSE  url_stripped
       END as url,      
     url_stripped,
     non_html_url,
@@ -103,7 +101,7 @@ FROM (
     url_protocol,
     canonical_url_protocol,
     is_canonicalized,
-    url_canonical_trailing_slash_match,
+    CASE WHEN substr(url_stripped,length(url),1) = substr(canonical_url_stripped,length(canonical_url),1) THEN 1 ELSE 0 END as url_canonical_trailing_slash_match,                    
     crawl_datetime,
     crawl_date,
     crawl_month,
@@ -190,7 +188,6 @@ FROM (
         case 
           when Canonical_Url is not null then 1
           else 0 end as is_canonicalized,
-        CASE WHEN substr(url,length(url),1) = substr(canonical_url,length(canonical_url),1) THEN 1 ELSE 0 END as url_canonical_trailing_slash_match,                    
         Crawl_Datetime as crawl_datetime,  
         cast(Crawl_Datetime as date) crawl_date,
         DATE_TRUNC(date( Crawl_Datetime ), month) crawl_month,
@@ -289,7 +286,6 @@ FROM (
         case 
           when canonical_url is not null then 1
           else 0 end as is_canonicalized,
-        CASE WHEN substr(url,length(url),1) = substr(canonical_url,length(canonical_url),1) THEN 1 ELSE 0 END as url_canonical_trailing_slash_match,          
         crawl_datetime,  
         cast(crawl_datetime as date) crawl_date,
         DATE_TRUNC(date( crawl_datetime ), month) crawl_month,

--- a/models/base/deepcrawl/deepcrawl_proc.sql
+++ b/models/base/deepcrawl/deepcrawl_proc.sql
@@ -360,7 +360,8 @@ FROM (
     WHERE self_redirect = 0 
     AND non_html_url = false
     WINDOW w1 as (PARTITION BY domain, crawl_report_month, url ORDER BY found_at_sitemap desc, is_canonicalized desc, crawl_datetime desc, eventid desc ),
-    w2 as (PARTITION BY domain, crawl_report_month ORDER BY crawl_id desc )
+    w2 as (PARTITION BY domain, crawl_report_month ORDER BY crawl_id desc ),
+    w3 as (PARTITION BY domain, crawl_id, canonical_url ORDER BY url_canonical_trailing_slash_match desc)
 )
 WHERE latest_crawl_datetime = crawl_datetime
 AND latest_crawl_id = crawl_id

--- a/models/base/deepcrawl/deepcrawl_proc.sql
+++ b/models/base/deepcrawl/deepcrawl_proc.sql
@@ -8,6 +8,8 @@ FROM (
   first_value(crawl_datetime) OVER w1 as latest_crawl_datetime,    
   first_value(query_string_url) over w1 as latest_query_string_url,
   first_value(eventid) over w1 as latest_event_id,
+  url_canonical_trailing_slash_match,
+  max(url_canonical_trailing_slash_match) over w3 as max_trailing_slash_match,
   eventid,
   domain,
   site,
@@ -101,6 +103,7 @@ FROM (
     url_protocol,
     canonical_url_protocol,
     is_canonicalized,
+    url_canonical_trailing_slash_match,
     crawl_datetime,
     crawl_date,
     crawl_month,
@@ -187,6 +190,7 @@ FROM (
         case 
           when Canonical_Url is not null then 1
           else 0 end as is_canonicalized,
+        CASE WHEN substr(url,length(url),1) = substr(canonical_url,length(canonical_url),1) THEN 1 ELSE 0 END as url_canonical_trailing_slash_match,                    
         Crawl_Datetime as crawl_datetime,  
         cast(Crawl_Datetime as date) crawl_date,
         DATE_TRUNC(date( Crawl_Datetime ), month) crawl_month,
@@ -285,6 +289,7 @@ FROM (
         case 
           when canonical_url is not null then 1
           else 0 end as is_canonicalized,
+        CASE WHEN substr(url,length(url),1) = substr(canonical_url,length(canonical_url),1) THEN 1 ELSE 0 END as url_canonical_trailing_slash_match,          
         crawl_datetime,  
         cast(crawl_datetime as date) crawl_date,
         DATE_TRUNC(date( crawl_datetime ), month) crawl_month,
@@ -439,4 +444,6 @@ GROUP BY   crawl_id,
   size,
   paginated_page,
   latest_event_id,
-  eventid
+  eventid,
+  url_canonical_trailing_slash_match,
+  max_url_canonical_trailing_slash_match


### PR DESCRIPTION
Solution for deduplicating trailing slashes in DC.

QC query (will contain one URL if fix works):

SELECT
url,
url_stripped,
canonical_url,
redirected_to_url,
self_redirect,
is_self_canonical,
is_canonicalized,
found_at_sitemap,
latest_query_string_url
FROM `inflow-recipes.wqa.deepcrawl_proc`
WHERE url in ( 'wh1.com/store/shop/pallet-rack', 'wh1.com/store/shop/pallet-rack/')
and crawl_id = 3001152
